### PR TITLE
Cache management should base on the templateId

### DIFF
--- a/src/Loader/TemplateLoader.php
+++ b/src/Loader/TemplateLoader.php
@@ -71,8 +71,8 @@ class TemplateLoader
     {
         $templateId = $name instanceof TemplateReferenceInterface ? $name->getLogicalName() : $name;
 
-        if (isset($this->cache[$name])) {
-            return $this->cache[$name];
+        if (isset($this->cache[$templateId])) {
+            return $this->cache[$templateId];
         }
 
         $template = $name instanceof TemplateReferenceInterface ? $name : $this->defaultTemplateParser->parse($name);


### PR DESCRIPTION
fix compile error
```shell
php bin/console smarty:compile
18:45:49 CRITICAL  [console] Error thrown while running command "smarty:compile". Message: "Illegal offset type in isset or empty" ["exception" => TypeError { …},"command" => "smarty:compile","message" => "Illegal offset type in isset or empty"]

In TemplateLoader.php line 77:

  Illegal offset type in isset or empty


smarty:compile [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] <command> [<bundle>]
```